### PR TITLE
Load family data from Google Sheets CSV

### DIFF
--- a/fetch-family-data.js
+++ b/fetch-family-data.js
@@ -1,0 +1,65 @@
+const CSV_URL = 'https://docs.google.com/spreadsheets/d/<YOUR_SHEET_ID>/export?format=csv';
+
+async function loadFamilyTree() {
+  try {
+    const response = await fetch(CSV_URL);
+    if (!response.ok) throw new Error('Network response was not ok');
+    const csvText = await response.text();
+    const rows = Papa.parse(csvText, { header: true, skipEmptyLines: true }).data;
+    const tree = buildHierarchy(rows);
+    const familyConfig = {
+      chart: {
+        container: '#tree-simple',
+        rootOrientation: 'NORTH',
+        connectors: { type: 'step' },
+        node: { collapsable: true }
+      },
+      nodeStructure: tree
+    };
+    collapseAll(familyConfig.nodeStructure);
+    new Treant(familyConfig);
+  } catch (err) {
+    console.error('Failed to load family data', err);
+  }
+}
+
+function buildHierarchy(rows) {
+  const nodes = {};
+  rows.forEach(row => {
+    const name = row['Name'].trim();
+    const spouse = row['Spouse'] ? row['Spouse'].trim() : '';
+    const label = spouse ? `${name}\n+ ${spouse}` : name;
+    nodes[name] = { text: { name: label } };
+  });
+
+  let root = null;
+  rows.forEach(row => {
+    const name = row['Name'].trim();
+    const parentKey = row['Parent'] ? row['Parent'].trim() : '';
+    if (!parentKey) {
+      root = nodes[name];
+    } else {
+      const parent = findParent(parentKey, nodes);
+      if (parent) {
+        parent.children = parent.children || [];
+        parent.children.push(nodes[name]);
+      }
+    }
+  });
+  return root;
+}
+
+function findParent(key, nodes) {
+  if (nodes[key]) return nodes[key];
+  const match = Object.keys(nodes).find(k => k.includes(key));
+  return match ? nodes[match] : null;
+}
+
+function collapseAll(node) {
+  if (node.children && node.children.length) {
+    node.collapsed = true;
+    node.children.forEach(collapseAll);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadFamilyTree);

--- a/index.html
+++ b/index.html
@@ -95,7 +95,8 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/fperucic/treant-js/vendor/raphael.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/fperucic/treant-js/Treant.js"></script>
-  <script src="family-data.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <script src="fetch-family-data.js"></script>
   
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new `fetch-family-data.js` to dynamically load the Google Sheets CSV
- build the Treant structure at runtime and collapse nodes
- update `index.html` to load Papa Parse and the new script instead of the static data file

## Testing
- `npm list papaparse` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6869a47b8238832f9c14799b9d426ebc