### PR TITLE
Disable local caching

### DIFF
--- a/fetch-family-data.js
+++ b/fetch-family-data.js
@@ -2,7 +2,7 @@ const CSV_URL = 'https://docs.google.com/spreadsheets/d/<YOUR_SHEET_ID>/export?f
 
 async function loadFamilyTree() {
   try {
-    const response = await fetch(CSV_URL);
+    const response = await fetch(CSV_URL, { cache: 'no-store' });
     if (!response.ok) throw new Error('Network response was not ok');
     const csvText = await response.text();
     const rows = Papa.parse(csvText, { header: true, skipEmptyLines: true }).data;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Family Tree</title>
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
 
   <!-- Treant.js and dependencies -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/fperucic/treant-js/Treant.css">


### PR DESCRIPTION
## Summary
- set `no-cache` headers in `index.html`
- disable caching when fetching CSV data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869a6cbf8c0832fb1d9c3bca9437440