### PR TITLE
Improve mobile interactions

### DIFF
--- a/fetch-family-data.js
+++ b/fetch-family-data.js
@@ -19,7 +19,16 @@ async function loadFamilyTree() {
       nodeStructure: tree
     };
     collapseChildren(familyConfig.nodeStructure);
-    new Treant(familyConfig);
+    new Treant(familyConfig, () => {
+      document.querySelectorAll('#tree-simple .node').forEach(nodeEl => {
+        nodeEl.addEventListener('click', e => {
+          if (!e.target.classList.contains('collapse-switch')) {
+            const toggle = nodeEl.querySelector('.collapse-switch');
+            if (toggle) toggle.click();
+          }
+        });
+      });
+    });
   } catch (err) {
     console.error('Failed to load family data', err);
   }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     text-align: center;
     line-height: 1.3;
     font-size: 1rem;
-    padding: 5px;
+    padding: 8px;
   }
 
   .Treant .node p {
@@ -55,7 +55,7 @@
 
     .Treant .node {
       font-size: 0.875rem;
-      padding: 3px;
+      padding: 6px;
     }
   }
   </style>
@@ -94,10 +94,15 @@
       font-weight: 900;
     }
 
-    .Treant .node.collapsed > .collapse-switch::after {
+  .Treant .node.collapsed > .collapse-switch::after {
       content: "\f067"; /* Font Awesome plus */
       font-family: "Font Awesome 6 Free";
       font-weight: 900;
+    }
+  </style>
+  <style>
+    .Treant .collapse-switch {
+      display: none;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak node padding for easier touch targets
- hide the Treant collapse icon
- make entire node toggle collapse state on click

## Testing
- `node --check fetch-family-data.js`

------
https://chatgpt.com/codex/tasks/task_e_686a6630762c832fa4892ca72c4ff8cb