### PR TITLE
Improve visibility of collapse icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,12 @@
   </style>
   <style>
     .Treant .collapse-switch {
-      display: none;
+      opacity: 0;
+      transition: opacity 0.2s;
+    }
+
+    .Treant .node:hover > .collapse-switch {
+      opacity: 1;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- inlined collapse switch styling so icons aren't permanently hidden
- show collapse icons on hover with CSS transitions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686a691d354c832f9a7002b5730ed9d6