### PR TITLE
Add card layout for family tree nodes

### DIFF
--- a/fetch-family-data.js
+++ b/fetch-family-data.js
@@ -34,13 +34,25 @@ async function loadFamilyTree() {
   }
 }
 
+function createCard(row) {
+  const name = row['Name'] ? row['Name'].trim() : '';
+  const details = Object.keys(row)
+    .filter(k => k !== 'Name' && k !== 'Parent' && row[k] && row[k].trim())
+    .map(k => `<div><strong>${k}:</strong> ${row[k].trim()}</div>`) 
+    .join('');
+  return `
+    <div class="family-card">
+      <div class="card-name">${name}</div>
+      ${details}
+    </div>
+  `;
+}
+
 function buildHierarchy(rows) {
   const nodes = {};
   rows.forEach(row => {
     const name = row['Name'].trim();
-    const spouse = row['Spouse'] ? row['Spouse'].trim() : '';
-    const label = spouse ? `${name}\n+ ${spouse}` : name;
-    nodes[name] = { text: { name: label } };
+    nodes[name] = { innerHTML: createCard(row) };
   });
 
   let root = null;

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
     font-size: 1rem;
     padding: 8px;
     cursor: pointer;
+    background-color: #fff;
+    border-radius: 8px;
+    border: 1px solid #ddd;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 
   .Treant .node:hover {
@@ -35,6 +39,15 @@
     margin: 0;
   }
 </style>
+  <style>
+  .family-card .card-name {
+    font-weight: bold;
+  }
+
+  .family-card div + div {
+    margin-top: 2px;
+  }
+  </style>
   <style>
   .scroll-wrapper {
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- style nodes as cards with borders and shadows
- show all available metadata in each node
- render node details dynamically from CSV data

## Testing
- `node -e "require('./fetch-family-data.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68733c49ae88832fbd5c267fab93b32b