### PR TITLE
Fix mobile auto-fit so the tree isn't cramped into a corner

### DIFF
--- a/fetch-family-data.js
+++ b/fetch-family-data.js
@@ -447,16 +447,44 @@ function zoomToFit() {
   tree.style.transition = 'none';
   tree.style.transform = 'scale(1)';
   currentZoom = 1; // sync state so setZoom's focal-point math is correct
-  const treeW = tree.scrollWidth;
-  const treeH = tree.scrollHeight;
+
+  // Measure only the bounding box of currently-visible nodes. Collapsed
+  // subtrees stay in the layout (Treant hides them with visibility:hidden,
+  // not display:none), so tree.scrollWidth/scrollHeight reflect the size of
+  // the *entire* tree rather than what's actually on screen — fitting to
+  // that produces a wildly over-shrunk view on a fresh page load.
+  const treeRect = tree.getBoundingClientRect();
+  const visibleNodes = Array.from(tree.querySelectorAll('.node'))
+    .filter(n => getComputedStyle(n).visibility !== 'hidden');
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  visibleNodes.forEach(n => {
+    const r = n.getBoundingClientRect();
+    minX = Math.min(minX, r.left - treeRect.left);
+    minY = Math.min(minY, r.top - treeRect.top);
+    maxX = Math.max(maxX, r.right - treeRect.left);
+    maxY = Math.max(maxY, r.bottom - treeRect.top);
+  });
   tree.style.transition = '';
+
+  if (!visibleNodes.length || !isFinite(minX)) {
+    setZoom(1);
+    return;
+  }
+
+  const treeW = maxX - minX;
+  const treeH = maxY - minY;
   const wrapperW = wrapper.clientWidth - 48; // account for padding
   const wrapperH = wrapper.clientHeight - 48;
   const fit = Math.min(wrapperW / treeW, wrapperH / treeH, 1);
   setZoom(fit);
-  // Center the tree after fitting
-  wrapper.scrollLeft = 0;
-  wrapper.scrollTop = 0;
+
+  // Scroll so the visible bounding box starts at the top-left of the
+  // viewport. Treant nodes are absolutely positioned within a container
+  // sized for the *entire* tree, so the visible ones are rarely anywhere
+  // near its (0, 0) — plain CSS centering can't reach absolutely
+  // positioned content, so this has to be done via scroll offset.
+  wrapper.scrollTop = Math.max(0, minY * fit);
+  wrapper.scrollLeft = Math.max(0, minX * fit);
 }
 
 function bindZoomControls() {


### PR DESCRIPTION
## Summary
- On iPhone, the tree loaded skewed into a corner at a tiny, unreadable zoom level (e.g. 28%), making it hard to see or operate.
- `zoomToFit()` measured `tree.scrollWidth`/`scrollHeight` to pick a fit scale, but Treant.js hides collapsed subtrees with `visibility:hidden` (not `display:none`), so those dimensions reflected the size of the *entire* tree's reserved layout rather than what's actually on screen. On a fresh mobile load (most nodes collapsed), this produced a wildly over-shrunk view, and the unconditional scroll reset to `(0,0)` then pinned whatever tiny content remained to the top-left corner.
- Fixed by measuring only the bounding box of currently-visible nodes, and scrolling to bring that box into view instead of blindly resetting to `(0,0)`.

## Test plan
- [x] Reproduced the bug and verified the fix locally: served the real `index.html`/`fetch-family-data.js` with a mocked `/api/family-data` response and a synthetic multi-generation tree, driven with headless Chromium at iPhone viewport dimensions.
- [x] Confirmed the pre-fix behavior measured `scrollHeight` in the thousands of pixels (reflecting hidden collapsed subtrees) versus a visible-node bounding box in the hundreds of pixels, producing an unnecessarily tiny auto-fit scale.
- [x] Confirmed post-fix the auto-fit scale reflects only visible content and the viewport scrolls to bring it fully into view.
- [ ] Manual check on an actual iPhone against the deployed site (not done — this session has no AWS credentials to deploy, so this branch hasn't gone to production yet).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MT6agcVgq6VhWUGRDdFopt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MT6agcVgq6VhWUGRDdFopt)_